### PR TITLE
Fixed the frontend routes not being exposed

### DIFF
--- a/src/Oro/Bundle/FrontendBundle/Extractor/FrontendExposedRoutesExtractor.php
+++ b/src/Oro/Bundle/FrontendBundle/Extractor/FrontendExposedRoutesExtractor.php
@@ -15,9 +15,11 @@ class FrontendExposedRoutesExtractor extends ExposedRoutesExtractor
      */
     public function isRouteExposed(Route $route, $name)
     {
-        return parent::isRouteExposed($route, $name) &&
-            $route->hasOption('frontend') &&
-            $route->getOption('frontend');
+        $pattern = $this->buildPattern();
+
+        return true === $route->getOption('frontend')
+            || 'true' === $route->getOption('frontend')
+            || ('' !== $pattern && preg_match('#' . $pattern . '#', $name));
     }
 
     /**


### PR DESCRIPTION
The public/media/js/frontend_routes.js was not providing every routes, I was facing an almost empty routing list and a JS routing error.

![image 4](https://user-images.githubusercontent.com/152367/53663807-02560280-3c67-11e9-99ed-4ae672a5f10c.png)

After digging into the code, the `Oro\Bundle\FrontendBundle\Extractor\FrontendExposedRoutesExtractor::isRouteExposed()` wasn't exposing routes having a `frontend: true` without also having an `exposed: true` route option, which resulted in JS routing errors.
