### PR TITLE
Make it easier to override the FrontendCustomerUserFormProvider  

### DIFF
--- a/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
+++ b/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
@@ -125,10 +125,6 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
     {
         $options = [];
 
-        if (isset($options['action'])) {
-            return $options;
-        }
-
         if ($customerUser->getId()) {
             $options['action'] = $this->generateUrl(
                 static::ACCOUNT_USER_UPDATE_ROUTE_NAME,
@@ -151,10 +147,6 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
     private function getProfilerFormOptions(CustomerUser $customerUser)
     {
         $options = [];
-
-        if (isset($options['action'])) {
-            return $options;
-        }
 
         if ($customerUser->getId()) {
             $options['action'] = $this->generateUrl(

--- a/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
+++ b/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
@@ -51,7 +51,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getForgotPasswordFormView(array $options = [])
     {
-        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
+        $options['action'] = $options['action'] ?? $this->generateUrl(static::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
 
         return $this->getFormView(CustomerUserPasswordRequestType::class, null, $options);
     }
@@ -63,7 +63,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getForgotPasswordForm(array $options = [])
     {
-        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
+        $options['action'] = $options['action'] ?? $this->generateUrl(static::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
 
         return $this->getForm(CustomerUserPasswordRequestType::class, null, $options);
     }
@@ -75,7 +75,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getResetPasswordFormView(CustomerUser $customerUser = null)
     {
-        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
+        $options['action'] = $options['action'] ?? $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
 
         return $this->getFormView(CustomerUserPasswordResetType::class, $customerUser, $options);
     }
@@ -87,7 +87,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getResetPasswordForm(CustomerUser $customerUser = null)
     {
-        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
+        $options['action'] = $options['action'] ?? $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
 
         return $this->getForm(CustomerUserPasswordResetType::class, $customerUser, $options);
     }

--- a/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
+++ b/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
@@ -75,7 +75,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getResetPasswordFormView(CustomerUser $customerUser = null)
     {
-        $options['action'] = $options['action'] ?? $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
+        $options['action'] = $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
 
         return $this->getFormView(CustomerUserPasswordResetType::class, $customerUser, $options);
     }
@@ -87,7 +87,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getResetPasswordForm(CustomerUser $customerUser = null)
     {
-        $options['action'] = $options['action'] ?? $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
+        $options['action'] = $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
 
         return $this->getForm(CustomerUserPasswordResetType::class, $customerUser, $options);
     }

--- a/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
+++ b/src/Oro/Bundle/CustomerBundle/Layout/DataProvider/FrontendCustomerUserFormProvider.php
@@ -51,7 +51,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getForgotPasswordFormView(array $options = [])
     {
-        $options['action'] = $this->generateUrl(self::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
+        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
 
         return $this->getFormView(CustomerUserPasswordRequestType::class, null, $options);
     }
@@ -63,7 +63,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getForgotPasswordForm(array $options = [])
     {
-        $options['action'] = $this->generateUrl(self::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
+        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_RESET_REQUEST_ROUTE_NAME);
 
         return $this->getForm(CustomerUserPasswordRequestType::class, null, $options);
     }
@@ -75,7 +75,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getResetPasswordFormView(CustomerUser $customerUser = null)
     {
-        $options['action'] = $this->generateUrl(self::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
+        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
 
         return $this->getFormView(CustomerUserPasswordResetType::class, $customerUser, $options);
     }
@@ -87,7 +87,7 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
      */
     public function getResetPasswordForm(CustomerUser $customerUser = null)
     {
-        $options['action'] = $this->generateUrl(self::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
+        $options['action'] = isset($options['action']) ?: $this->generateUrl(static::ACCOUNT_USER_PASSWORD_RESET_ROUTE_NAME);
 
         return $this->getForm(CustomerUserPasswordResetType::class, $customerUser, $options);
     }
@@ -125,14 +125,18 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
     {
         $options = [];
 
+        if (isset($options['action'])) {
+            return $options;
+        }
+
         if ($customerUser->getId()) {
             $options['action'] = $this->generateUrl(
-                self::ACCOUNT_USER_UPDATE_ROUTE_NAME,
+                static::ACCOUNT_USER_UPDATE_ROUTE_NAME,
                 ['id' => $customerUser->getId()]
             );
         } else {
             $options['action'] = $this->generateUrl(
-                self::ACCOUNT_USER_CREATE_ROUTE_NAME
+                static::ACCOUNT_USER_CREATE_ROUTE_NAME
             );
         }
 
@@ -147,9 +151,14 @@ class FrontendCustomerUserFormProvider extends AbstractFormProvider
     private function getProfilerFormOptions(CustomerUser $customerUser)
     {
         $options = [];
+
+        if (isset($options['action'])) {
+            return $options;
+        }
+
         if ($customerUser->getId()) {
             $options['action'] = $this->generateUrl(
-                self::ACCOUNT_USER_PROFILE_UPDATE_ROUTE_NAME,
+                static::ACCOUNT_USER_PROFILE_UPDATE_ROUTE_NAME,
                 ['id' => $customerUser->getId()]
             );
 


### PR DESCRIPTION
- FrontendCustomerUserFormProvider : Make it easier to override
- ResetController : use symfony standards