### PR TITLE
add onDelete cascade on foreign key constraint between MenuUpdate and Scope

### DIFF
--- a/src/Oro/Bundle/CommerceMenuBundle/Migrations/Schema/OroCommerceMenuBundleInstaller.php
+++ b/src/Oro/Bundle/CommerceMenuBundle/Migrations/Schema/OroCommerceMenuBundleInstaller.php
@@ -29,7 +29,7 @@ class OroCommerceMenuBundleInstaller implements
      */
     public function getMigrationVersion()
     {
-        return 'v1_7';
+        return 'v1_8';
     }
 
     /**
@@ -188,7 +188,8 @@ class OroCommerceMenuBundleInstaller implements
         $table->addForeignKeyConstraint(
             $schema->getTable('oro_scope'),
             ['scope_id'],
-            ['id']
+            ['id'],
+            ['onUpdate' => null, 'onDelete' => 'CASCADE']
         );
         $table->addForeignKeyConstraint(
             $schema->getTable('oro_web_catalog_content_node'),

--- a/src/Oro/Bundle/CommerceMenuBundle/Migrations/Schema/v1_8/AddScopeToMenuUpdateTable.php
+++ b/src/Oro/Bundle/CommerceMenuBundle/Migrations/Schema/v1_8/AddScopeToMenuUpdateTable.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Oro\Bundle\CommerceMenuBundle\Migrations\Schema\v1_8;
+
+use Doctrine\DBAL\Schema\Schema;
+use Oro\Bundle\MigrationBundle\Migration\Migration;
+use Oro\Bundle\MigrationBundle\Migration\QueryBag;
+
+class AddScopeToMenuUpdateTable implements Migration
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function up(Schema $schema, QueryBag $queries)
+    {
+        /** Table updates **/
+        $this->addOroCommerceMenuUpdateForeignKeys($schema);
+    }
+
+    /**
+     * Add oro_commerce_menu_upd foreign keys.
+     *
+     * @param Schema $schema
+     */
+    protected function addOroCommerceMenuUpdateForeignKeys(Schema $schema)
+    {
+        $table = $schema->getTable('oro_commerce_menu_upd');
+        $table->addForeignKeyConstraint(
+            $schema->getTable('oro_scope'),
+            ['scope_id'],
+            ['id'],
+            ['onUpdate' => null, 'onDelete' => 'CASCADE']
+        );
+    }
+}


### PR DESCRIPTION
Hi,

I got an error in version 4.2RC while trying to delete a Website : 
```
  An exception occurred while executing 'DELETE FROM oro_website WHERE id = ?  ' with params [1]:
  SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table "oro_scope" violates foreign key constraint "fk_8e13dcb9682b5931" on table  "oro_commerce_menu_upd"
  DETAIL:  Key (id)=(2) is still referenced from table "oro_commerce_menu_upd".

```
Due to an entry in table oro_commerce_menu_upd (Oro\Bundle\CommerceMenuBundle\Entity\MenuUpdate class) linked to Scope which is linked to the Website.

So I did like the AddScopeToMenuUpdateTable.php file of v1_2 and fixed the adding of foreign key constraint and I fixed the OroCommerceMenuBundleInstaller.php.

Best regards.