### PR TITLE
Add test for CustomerUser import without ID and email address

### DIFF
--- a/src/Oro/Bundle/CustomerBundle/Tests/Functional/ImportExport/Import/ImportCustomerUserTest.php
+++ b/src/Oro/Bundle/CustomerBundle/Tests/Functional/ImportExport/Import/ImportCustomerUserTest.php
@@ -50,6 +50,9 @@ class ImportCustomerUserTest extends WebTestCase
         return [
             'customer_users_with_existing_id_and_not_valid_customer' => [
                 'fixtureName' => 'customer_users_with_existing_id_and_not_valid_customer',
+            ],
+            'customer_users_without_existing_id_and_email' => [
+                'fixtureName' => 'customer_users_without_existing_id_and_email',
             ]
         ];
     }

--- a/src/Oro/Bundle/CustomerBundle/Tests/Functional/ImportExport/Import/fixtures/customer_users_without_existing_id_and_email.csv
+++ b/src/Oro/Bundle/CustomerBundle/Tests/Functional/ImportExport/Import/fixtures/customer_users_without_existing_id_and_email.csv
@@ -1,0 +1,2 @@
+ID,First Name,Middle Name,Last Name,Name Suffix,Birthday,Email Address,Customer Id,Customer Name,Roles 1 Role,Enabled,Confirmed,Owner Id,Website Id
+,Marco,Gander,Postance,III,6/22/1965,,1,,ROLE_FRONTEND_BUYER,1,0,1,1


### PR DESCRIPTION
Related to #14
Depends on oroinc/platform#1140

## Changes

- Add fixture `customer_users_without_existing_id_and_email.csv` reproducing the scenario
- Add test case `customer_users_without_existing_id_and_email` in `ImportCustomerUserTest`

The test currently fails and will pass once oroinc/platform#1140 is merged.

---

> Note: this test is provided as a complement to oroinc/platform#1140.
> Feel free to adjust or discard it if it does not fit the testing conventions.